### PR TITLE
Handle non-JSON API responses and upgrade Alpine base image

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy using GoStatic
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy
         id: deploy
         uses: DigitalSVN/GoStatic@main
@@ -17,10 +17,10 @@ jobs:
         run: echo "URL ${{ steps.deploy.outputs.url }}"
 
       - name: Output the deployment URL in a comment on the pull request
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: 'URL ready:  ${{ steps.deploy.outputs.url }}' });
+            github.rest.issues.createComment({ issue_number, owner, repo, body: 'URL ready:  ${{ steps.deploy.outputs.url }}' });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+GoStatic is a Docker-based GitHub Action that deploys static sites to the GoStatic cloud service (`https://www.gostaticapp.com`).
+
+## How It Works
+
+1. `action.yml` defines two inputs (`api-token`, `source-dir`) and two outputs (`url`, `deployment_id`)
+2. The Docker container runs `entrypoint.sh`, which:
+   - Warns if `index.html` is missing from the source directory
+   - Creates a gzipped tar of the source directory
+   - POSTs it to `https://www.gostaticapp.com/api/deploy/artifact` with Bearer token auth
+   - Parses the JSON response with `jq` and sets GitHub Action outputs
+
+## Local Development
+
+```bash
+# Build the Docker image locally
+docker build -t gostatic:latest .
+
+# Run the entrypoint directly (requires a real API token)
+./entrypoint.sh "./example_output_directory" "YOUR_API_TOKEN"
+```
+
+There is no automated test suite. Manual testing requires a real GoStatic API token.
+
+## Key Files
+
+- [`entrypoint.sh`](entrypoint.sh) — core logic: tar, POST, parse response
+- [`action.yml`](action.yml) — action interface (inputs/outputs/branding)
+- [`Dockerfile`](Dockerfile) — Alpine 3.23 with `curl` and `jq`
+- [`.github/workflows/example.yml`](.github/workflows/example.yml) — reference workflow showing how to use the action and post deployment URLs as PR comments
+- [`example_output_directory/`](example_output_directory/) — sample static site for testing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.23
 
 # Install the curl and jq packages
 RUN apk --no-cache add curl jq

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy using GoStatic
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy
         id: deploy
         uses: DigitalSVN/GoStatic@v1.1
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy using GoStatic
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Deploy
         id: deploy
         uses: DigitalSVN/GoStatic@v1.1
@@ -60,13 +60,13 @@ jobs:
           source-dir: './example_output_directory'
 
       - name: Output the deployment URL in a comment on the pull request
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: 'URL ready:  ${{ steps.deploy.outputs.url }}' });
+            github.rest.issues.createComment({ issue_number, owner, repo, body: 'URL ready:  ${{ steps.deploy.outputs.url }}' });
 ```
 
 ### Prerequisites

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,17 +35,24 @@ http_response_code=$(curl --silent --write-out "%{http_code}" --output response.
 
 response_content=$(cat response.txt)
 
-content_deployment_id=$(echo $response_content | jq -r '.deployment_id')
-content_message=$(echo $response_content | jq -r '.message')
-content_error=$(echo $response_content | jq -r '.error')
-content_status=$(echo $response_content | jq -r '.status')
-content_url=$(echo $response_content | jq -r '.url')
-
 rm artifact.tar.gz
 rm response.txt
 
-if [[ "$http_response_code" != "201" ]]; then
-  echo "Code:$http_response_code\nMessage:$content_message\nError:$content_error"
+if ! echo "$response_content" | jq -e . > /dev/null 2>&1; then
+  echo "Error: API returned a non-JSON response (HTTP $http_response_code)"
+  echo "Response: $response_content"
+  exit 1
+fi
+
+content_deployment_id=$(echo $response_content | jq -r '.deployment_id')
+content_message=$(echo $response_content | jq -r '.message')
+content_error=$(echo $response_content | jq -r '.error')
+content_url=$(echo $response_content | jq -r '.url')
+
+if [ "$http_response_code" != "201" ]; then
+  echo "Error: Deployment failed (HTTP $http_response_code)"
+  echo "Message: $content_message"
+  echo "Error: $content_error"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds JSON validation before parsing the API response with `jq`, so non-JSON responses (e.g. HTML timeout pages, gateway errors) produce a clear, human-readable error instead of a cryptic `jq` parse error
- Fixes broken `\n` escape sequences in the non-201 error output (these didn't expand in `sh`)
- Removes unused `content_status` variable
- Upgrades Dockerfile base image from `alpine:3.13` to `alpine:3.23`
- Adds `CLAUDE.md` with project guidance for AI-assisted development

## What changed and why

When the GoStatic API times out or returns a non-JSON response, callers were seeing:

```
parse error: Invalid numeric literal at line 1, column 6
```

with no indication of what HTTP status was returned or what the raw response contained. The fix validates the response with `jq -e .` before attempting to parse it, and on failure prints both the HTTP status code and the raw response body so the caller can diagnose the issue.

## Reviewer notes

- No functional change to the happy path
- The cleanup order changed slightly: `artifact.tar.gz` and `response.txt` are now removed before the JSON check (so temp files are always cleaned up, even on error)